### PR TITLE
Treat Paraprofessionals as if they were always hired before July 1, 2021

### DIFF
--- a/src/app/common/services/healthcare-rates/healthcare-rates.service.interface.ts
+++ b/src/app/common/services/healthcare-rates/healthcare-rates.service.interface.ts
@@ -7,20 +7,18 @@ export abstract class IHealthcareRatesService {
   abstract getContractKeys(): ContractName[];
   abstract getContractSalaryType(contractName: ContractName | undefined): SalaryType | undefined;
   abstract getCompletedYearsOptions(): CompletedYears[];
-  abstract getHireDateOptions(): HireDate[];
   abstract getPayPeriodOptions(): PayPeriod[];
   abstract getContractDeductions(contractName: ContractName | undefined, payPeriods: number | undefined): number | undefined
-  abstract getDeductionResults(contractName: ContractName, inputSalary: number | undefined, completedYears: CompletedYears | undefined, hireDate: HireDate | undefined, payPeriods: number | undefined): DeductionResults
+  abstract getDeductionResults(contractName: ContractName, inputSalary: number | undefined, completedYears: CompletedYears | undefined, payPeriods: number | undefined): DeductionResults
 }
 
 export enum SalaryType {
   NoService = 0,
   SalaryAndYearsAndPayPeriod = 1,
-  SalaryAndHireDate = 2,
-  SalaryAndPayPeriod = 3,
-  SalaryOnly = 4,
-  FlatRate = 5,
-  FullCost = 6
+  SalaryAndPayPeriod = 2,
+  SalaryOnly = 3,
+  FlatRate = 4,
+  FullCost = 5
 }
 
 export enum ContractName {
@@ -40,11 +38,6 @@ export enum CompletedYears {
   ZeroToOne = "0-1",
   TwoToThree = "2-3",
   FourOrMore = "4+"
-}
-
-export enum HireDate {
-  OnOrAfter_2022_07_01 = "Yes",
-  Before_2022_07_01 = "No",
 }
 
 export interface DeductionResults {

--- a/src/app/common/services/healthcare-rates/healthcare-rates.service.ts
+++ b/src/app/common/services/healthcare-rates/healthcare-rates.service.ts
@@ -46,10 +46,10 @@ export class HealthcareRatesService implements IHealthcareRatesService {
         }],
         [ContractName.Paraprofessional, {
             salaryType: SalaryType.SalaryAndHireDate, deductionGetter: SingleDeduction(19.0),
-            hipLowCalculation: WhenHireDateIs(HireDate.Before_2022_07_01, TypicalCalculation, CalculationDisabled),
-            nyshipEmpireCalculation: WhenHireDateIs(HireDate.Before_2022_07_01, TypicalCalculation, CalculationDisabled),
-            nyshipExcelsiorCalculation: WhenHireDateIs(HireDate.OnOrAfter_2022_07_01, TypicalCalculation, CalculationDisabled),
-            hipHighCalculation: WhenHireDateIs(HireDate.Before_2022_07_01, LimitedHipHigh, CalculationDisabled)
+            hipLowCalculation: TypicalCalculation,
+            nyshipEmpireCalculation: TypicalCalculation,
+            nyshipExcelsiorCalculation: CalculationDisabled,
+            hipHighCalculation: LimitedHipHigh
         }],
         [ContractName.FoodService, {
             salaryType: SalaryType.NoService, deductionGetter: SingleDeduction(0.0),
@@ -286,16 +286,6 @@ function LimitedHipHigh(deduction: number, percentPaying: number, rateHip: numbe
 function TypicalCalculation(deduction: number, percentPaying: number, rate: number, _: number, __: HireDate | undefined) {
     const result = 12 * rate * percentPaying / deduction;
     return roundResult(result);
-}
-
-function WhenHireDateIs(hireDateEquals: HireDate, trueCalc: ContractDefinitionCalculation, falseCalc: ContractDefinitionCalculation): ContractDefinitionCalculation {
-    return (deduction: number, percentPaying: number, rateHip: number, rateNyship: number, hireDate: HireDate | undefined) => {
-        if (hireDate === hireDateEquals) {
-            return trueCalc(deduction, percentPaying, rateHip, rateNyship, hireDate);
-        } else {
-            return falseCalc(deduction, percentPaying, rateHip, rateNyship, hireDate);
-        }
-    }
 }
 
 function ContactMessage(_: number, __: number, ___: number, ____: number, _____: HireDate | undefined) {

--- a/src/app/common/services/healthcare-rates/healthcare-rates.service.ts
+++ b/src/app/common/services/healthcare-rates/healthcare-rates.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ContractName, IHealthcareRatesService, DeductionResults, SalaryType, CompletedYears, HireDate } from '@/common/services/healthcare-rates/healthcare-rates.service.interface';
+import { ContractName, IHealthcareRatesService, DeductionResults, SalaryType, CompletedYears } from '@/common/services/healthcare-rates/healthcare-rates.service.interface';
 import { PayPeriod } from '@/common/models/PayPeriod';
 
 @Injectable({
@@ -45,7 +45,7 @@ export class HealthcareRatesService implements IHealthcareRatesService {
             hipHighCalculation: LimitedHipHigh,
         }],
         [ContractName.Paraprofessional, {
-            salaryType: SalaryType.SalaryAndHireDate, deductionGetter: SingleDeduction(19.0),
+            salaryType: SalaryType.SalaryOnly, deductionGetter: SingleDeduction(19.0),
             hipLowCalculation: TypicalCalculation,
             nyshipEmpireCalculation: TypicalCalculation,
             nyshipExcelsiorCalculation: CalculationDisabled,
@@ -108,9 +108,6 @@ export class HealthcareRatesService implements IHealthcareRatesService {
     getCompletedYearsOptions(): CompletedYears[] {
         return Object.values(CompletedYears);
     }
-    getHireDateOptions(): HireDate[] {
-        return Object.values(HireDate);
-    }
     getPayPeriodOptions(): PayPeriod[] {
         return [
             { text: "10 month", value: 19.0 },
@@ -127,7 +124,7 @@ export class HealthcareRatesService implements IHealthcareRatesService {
         return selectedContract.deductionGetter(payPeriods)
     }
 
-    getDeductionResults(contractName: ContractName, inputSalary: number, completedYears: CompletedYears | undefined, hireDate: HireDate | undefined, payPeriods: number | undefined): DeductionResults {
+    getDeductionResults(contractName: ContractName, inputSalary: number, completedYears: CompletedYears | undefined, payPeriods: number | undefined): DeductionResults {
         const selectedContract = this.contracts.get(contractName);
         if (selectedContract === undefined) {
             console.error("Unable to retrieve contract from: ", contractName);
@@ -157,38 +154,38 @@ export class HealthcareRatesService implements IHealthcareRatesService {
         const calculatedResult: DeductionResults = {
             perPayroll: {
                 hipLow: {
-                    individual: selectedContract.hipLowCalculation(contractDeduction, percent, this.rates.hipLow.individual, 0, hireDate),
-                    family: selectedContract.hipLowCalculation(contractDeduction, percent, this.rates.hipLow.family, 0, hireDate),
+                    individual: selectedContract.hipLowCalculation(contractDeduction, percent, this.rates.hipLow.individual, 0),
+                    family: selectedContract.hipLowCalculation(contractDeduction, percent, this.rates.hipLow.family, 0),
                 },
                 nyshipEmpire: {
-                    individual: selectedContract.nyshipEmpireCalculation(contractDeduction, percent, this.rates.nyshipEmpire.individual, 0, hireDate),
-                    family: selectedContract.nyshipEmpireCalculation(contractDeduction, percent, this.rates.nyshipEmpire.family, 0, hireDate),
+                    individual: selectedContract.nyshipEmpireCalculation(contractDeduction, percent, this.rates.nyshipEmpire.individual, 0),
+                    family: selectedContract.nyshipEmpireCalculation(contractDeduction, percent, this.rates.nyshipEmpire.family, 0),
                 },
                 nyshipExcelsior: {
-                    individual: selectedContract.nyshipExcelsiorCalculation(contractDeduction, percent, this.rates.nyshipExcelsior.individual, 0, hireDate),
-                    family: selectedContract.nyshipExcelsiorCalculation(contractDeduction, percent, this.rates.nyshipExcelsior.family, 0, hireDate),
+                    individual: selectedContract.nyshipExcelsiorCalculation(contractDeduction, percent, this.rates.nyshipExcelsior.individual, 0),
+                    family: selectedContract.nyshipExcelsiorCalculation(contractDeduction, percent, this.rates.nyshipExcelsior.family, 0),
                 },
                 hipHigh: {
-                    individual: selectedContract.hipHighCalculation(contractDeduction, percent, this.rates.hipHigh.individual, this.rates.nyshipEmpire.individual, hireDate),
-                    family: selectedContract.hipHighCalculation(contractDeduction, percent, this.rates.hipHigh.family, this.rates.nyshipEmpire.family, hireDate),
+                    individual: selectedContract.hipHighCalculation(contractDeduction, percent, this.rates.hipHigh.individual, this.rates.nyshipEmpire.individual),
+                    family: selectedContract.hipHighCalculation(contractDeduction, percent, this.rates.hipHigh.family, this.rates.nyshipEmpire.family),
                 }
             },
             perMonth: {
                 hipLow: {
-                    individual: selectedContract.hipLowCalculation(monthsInYear, percent, this.rates.hipLow.individual, 0, hireDate),
-                    family: selectedContract.hipLowCalculation(monthsInYear, percent, this.rates.hipLow.family, 0, hireDate),
+                    individual: selectedContract.hipLowCalculation(monthsInYear, percent, this.rates.hipLow.individual, 0),
+                    family: selectedContract.hipLowCalculation(monthsInYear, percent, this.rates.hipLow.family, 0),
                 },
                 nyshipEmpire: {
-                    individual: selectedContract.nyshipEmpireCalculation(monthsInYear, percent, this.rates.nyshipEmpire.individual, 0, hireDate),
-                    family: selectedContract.nyshipEmpireCalculation(monthsInYear, percent, this.rates.nyshipEmpire.family, 0, hireDate),
+                    individual: selectedContract.nyshipEmpireCalculation(monthsInYear, percent, this.rates.nyshipEmpire.individual, 0),
+                    family: selectedContract.nyshipEmpireCalculation(monthsInYear, percent, this.rates.nyshipEmpire.family, 0),
                 },
                 nyshipExcelsior: {
-                    individual: selectedContract.nyshipExcelsiorCalculation(monthsInYear, percent, this.rates.nyshipExcelsior.individual, 0, hireDate),
-                    family: selectedContract.nyshipExcelsiorCalculation(monthsInYear, percent, this.rates.nyshipExcelsior.family, 0, hireDate),
+                    individual: selectedContract.nyshipExcelsiorCalculation(monthsInYear, percent, this.rates.nyshipExcelsior.individual, 0),
+                    family: selectedContract.nyshipExcelsiorCalculation(monthsInYear, percent, this.rates.nyshipExcelsior.family, 0),
                 },
                 hipHigh: {
-                    individual: selectedContract.hipHighCalculation(monthsInYear, percent, this.rates.hipHigh.individual, this.rates.nyshipEmpire.individual, hireDate),
-                    family: selectedContract.hipHighCalculation(monthsInYear, percent, this.rates.hipHigh.family, this.rates.nyshipEmpire.family, hireDate),
+                    individual: selectedContract.hipHighCalculation(monthsInYear, percent, this.rates.hipHigh.individual, this.rates.nyshipEmpire.individual),
+                    family: selectedContract.hipHighCalculation(monthsInYear, percent, this.rates.hipHigh.family, this.rates.nyshipEmpire.family),
                 }
             }
         };
@@ -272,29 +269,29 @@ function PassThroughDeduction(): DeductionGetter {
 
 
 //Contract Definition Calculation
-type ContractDefinitionCalculation = (deduction: number, percentPaying: number, rate: number, rateAlt: number, hireDate: HireDate | undefined) => string | undefined;
+type ContractDefinitionCalculation = (deduction: number, percentPaying: number, rate: number, rateAlt: number) => string | undefined;
 
 function roundResult(result: number) {
     return (result + .005).toFixed(2).toString();
 }
 
-function LimitedHipHigh(deduction: number, percentPaying: number, rateHip: number, rateNyship: number, _: HireDate | undefined) {
+function LimitedHipHigh(deduction: number, percentPaying: number, rateHip: number, rateNyship: number) {
     const result = (12 * rateHip * percentPaying / deduction) + 12 * (1 - percentPaying) * (rateHip - rateNyship) / deduction;
     return roundResult(result);
 }
 
-function TypicalCalculation(deduction: number, percentPaying: number, rate: number, _: number, __: HireDate | undefined) {
+function TypicalCalculation(deduction: number, percentPaying: number, rate: number, _: number) {
     const result = 12 * rate * percentPaying / deduction;
     return roundResult(result);
 }
 
-function ContactMessage(_: number, __: number, ___: number, ____: number, _____: HireDate | undefined) {
+function ContactMessage(_: number, __: number, ___: number, ____: number) {
     return "Contact the Benefits Department";
 }
-function NotAvailable(_: number, __: number, ___: number, ____: number, _____: HireDate | undefined) {
+function NotAvailable(_: number, __: number, ___: number, ____: number) {
     return "Not available";
 }
 
-function CalculationDisabled(_: number, __: number, ___: number, ____: number, _____: HireDate | undefined) {
+function CalculationDisabled(_: number, __: number, ___: number, ____: number) {
     return undefined;
 }

--- a/src/app/pages/healthcare-rates/healthcare-rates.component.html
+++ b/src/app/pages/healthcare-rates/healthcare-rates.component.html
@@ -42,21 +42,6 @@
                     </div>
                 </div>
             </section>
-            <section name="Hire Date" *ngIf="isShowingHireDate" class="col-12">
-                <div class="row mx-0">
-                    <div class="col-md-6 my-auto">
-                        <label>Were you hired on or after July 1, 2021?</label>
-                    </div>
-                    <div class="col-12 col-md">
-                        <select [ngModel]="hireDate" (ngModelChange)="onSelectHireDate($event)"
-                        class="form-select" aria-label="Contract Name">
-                        <option *ngFor="let hireOption of hireDateOptions" [ngValue]="hireOption">
-                            {{hireOption}}
-                        </option>
-                    </select>
-                    </div>
-                </div>
-            </section>
             <section name="Pay Period" *ngIf="isShowingPayPeriod" class="col-12">
                 <div class="row mx-0">
                     <div class="col-md-6 my-auto">

--- a/src/app/pages/healthcare-rates/healthcare-rates.component.ts
+++ b/src/app/pages/healthcare-rates/healthcare-rates.component.ts
@@ -1,6 +1,6 @@
 import { PayPeriod } from '@/app/common/models/PayPeriod';
 import { ErrorAlertItem, IErrorAlertsService } from '@/app/common/services/error-alerts/error-alerts.service.interface';
-import { CompletedYears, ContractName, DeductionResults, HireDate, IHealthcareRatesService, SalaryType } from '@/app/common/services/healthcare-rates/healthcare-rates.service.interface';
+import { CompletedYears, ContractName, DeductionResults, IHealthcareRatesService, SalaryType } from '@/app/common/services/healthcare-rates/healthcare-rates.service.interface';
 import { INavbarDataService } from '@/app/common/services/navbar-data/navbar-data.service.interface';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 
@@ -24,10 +24,6 @@ export class HealthcareRatesComponent implements OnInit, OnDestroy {
   completedYearsOptions: CompletedYears[];
   completedYears: CompletedYears | undefined;
 
-  isShowingHireDate: boolean;
-  hireDateOptions: HireDate[];
-  hireDate: HireDate | undefined;
-
   isShowingPayPeriod: boolean;
   payPeriodOptions: PayPeriod[];
   payPeriod: PayPeriod | undefined;
@@ -37,12 +33,10 @@ export class HealthcareRatesComponent implements OnInit, OnDestroy {
   constructor(private readonly _healthcareService: IHealthcareRatesService, private readonly _errorAlertsService: IErrorAlertsService, private readonly _navbarDataService: INavbarDataService) {
     this.contractNameOptions = this._healthcareService.getContractKeys();
     this.completedYearsOptions = this._healthcareService.getCompletedYearsOptions();
-    this.hireDateOptions = this._healthcareService.getHireDateOptions();
     this.payPeriodOptions = this._healthcareService.getPayPeriodOptions();
 
     this.isShowingSalaryInput = false;
     this.isShowingCompletedYears = false;
-    this.isShowingHireDate = false;
     this.isShowingPayPeriod = false;
   }
 
@@ -64,12 +58,10 @@ export class HealthcareRatesComponent implements OnInit, OnDestroy {
     if (this.contractSalaryType === undefined) {
       this.isShowingSalaryInput = false;
       this.isShowingCompletedYears = false;
-      this.isShowingHireDate = false;
       this.isShowingPayPeriod = false;
     } else {
-      this.isShowingSalaryInput = [SalaryType.SalaryAndYearsAndPayPeriod, SalaryType.SalaryOnly, SalaryType.SalaryAndHireDate, SalaryType.SalaryAndPayPeriod].includes(this.contractSalaryType);
+      this.isShowingSalaryInput = [SalaryType.SalaryAndYearsAndPayPeriod, SalaryType.SalaryOnly, SalaryType.SalaryAndPayPeriod].includes(this.contractSalaryType);
       this.isShowingCompletedYears = [SalaryType.SalaryAndYearsAndPayPeriod].includes(this.contractSalaryType);
-      this.isShowingHireDate = [SalaryType.SalaryAndHireDate].includes(this.contractSalaryType);
       this.isShowingPayPeriod = [SalaryType.SalaryAndYearsAndPayPeriod, SalaryType.SalaryAndPayPeriod].includes(this.contractSalaryType);
     }
     this.clearUnusedInputs();
@@ -80,9 +72,6 @@ export class HealthcareRatesComponent implements OnInit, OnDestroy {
     }
     if (!this.isShowingCompletedYears) {
       this.completedYears = undefined;
-    }
-    if (!this.isShowingHireDate) {
-      this.hireDate = undefined;
     }
     if (!this.isShowingPayPeriod) {
       this.payPeriod = undefined;
@@ -95,10 +84,6 @@ export class HealthcareRatesComponent implements OnInit, OnDestroy {
   onSelectCompletedYears(newCompletedYears: CompletedYears) {
     this.deductionResults = undefined;
     this.completedYears = newCompletedYears;
-  }
-  onSelectHireDate(newHireDate: HireDate) {
-    this.deductionResults = undefined;
-    this.hireDate = newHireDate;
   }
   onSelectPayPeriod(newPayPeriod: PayPeriod) {
     this.deductionResults = undefined;
@@ -126,11 +111,6 @@ export class HealthcareRatesComponent implements OnInit, OnDestroy {
         "Please select the number of years you've completed",
         this.healthCareRatesErrorScope, autoDismissDelay));
     }
-    if (this.isShowingHireDate && (this.hireDate === undefined || !this.hireDateOptions.includes(this.hireDate))) {
-      errors.push(new ErrorAlertItem(
-        "Please select the applicable hire date",
-        this.healthCareRatesErrorScope, autoDismissDelay));
-    }
     if (this.isShowingPayPeriod && (this.payPeriod === undefined || !this.payPeriodOptions.includes(this.payPeriod))) {
       errors.push(new ErrorAlertItem(
         "Please select the applicable pay period",
@@ -150,6 +130,6 @@ export class HealthcareRatesComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.deductionResults = this._healthcareService.getDeductionResults(this.contractName!, this.salary!, this.completedYears!, this.hireDate, this.payPeriod?.value);
+    this.deductionResults = this._healthcareService.getDeductionResults(this.contractName!, this.salary!, this.completedYears!, this.payPeriod?.value);
   }
 }


### PR DESCRIPTION
- Remove the `Were you hired on or after July 1, 2021?` question and any references/usages of it
- For paraprofessionals , use the calculations associated with an answer of `No` to `Were you hired on or after July 1, 2021?`
- Change paraprofessionals to the `SalaryOnly` salary type (that will be the only additional question their contract-type is asked)